### PR TITLE
Disable prop-types errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,7 @@ module.exports = {
     ],
     "react/jsx-props-no-spreading": "off",
     "react/prop-types": "warn",
+    "react/require-default-props": "off"
   },
   settings: {
     "import/resolver": {


### PR DESCRIPTION
Disable require-default-props since typescript is giving enough information