### PR TITLE
Disallow multi-line curly

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports = {
       },
     ],
     "consistent-return": "off",
-    "curly": "error",
+    "curly": ["error", "all"],
     "import/default": 2,
     "import/export": 2,
     "import/named": 2,

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ module.exports = {
       },
     ],
     "consistent-return": "off",
+    "curly": "error",
     "import/default": 2,
     "import/export": 2,
     "import/named": 2,


### PR DESCRIPTION
Disallow omitting curly braces around blocks, even when they are optional, because it can lead to bugs and reduces code clarity